### PR TITLE
Add event duration to FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,13 @@
                         <p class="text-gray-600">There will be no food available, and Mapleside facilities will be closed.</p>
                     </div>
                 </div>
+
+                <div class="mb-6">
+                    <div class="bg-white p-6 rounded-lg shadow-md">
+                        <h3 class="font-bold text-lg mb-2 text-amber-800">How long will the event last?</h3>
+                        <p class="text-gray-600">The evening is expected to run for approximately 90 minutes.</p>
+                    </div>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- update index.html FAQ section to mention the event runs around 90 minutes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687851eb7e44832daa18d274a6052b88